### PR TITLE
ClassGenFix

### DIFF
--- a/src/MsSqlToolBelt/Business/ClassGenManager.cs
+++ b/src/MsSqlToolBelt/Business/ClassGenManager.cs
@@ -521,7 +521,7 @@ public sealed class ClassGenManager : IDisposable
         var columnAttributes = new List<string>();
         if (!string.IsNullOrEmpty(column.Alias) && !column.Name.EqualsIgnoreCase(column.Alias))
         {
-            columnAttributes.Add($"[Column[\"{column.Name}\")]");
+            columnAttributes.Add($"[Column(\"{column.Name}\")]");
         }
 
         if (column.DataType.EqualsIgnoreCase("date"))


### PR DESCRIPTION
Fixed a bug in the class generator which creates `[Column[Name)]` instead of `[Column(Name)]`