### PR TITLE
Table definition fix

### DIFF
--- a/src/MsSqlToolBelt/Common/Enums/SearchViewType.cs
+++ b/src/MsSqlToolBelt/Common/Enums/SearchViewType.cs
@@ -6,6 +6,11 @@
 public enum SearchViewType
 {
     /// <summary>
+    /// Show an info
+    /// </summary>
+    None,
+
+    /// <summary>
     /// Shows the SQL preview
     /// </summary>
     Sql,

--- a/src/MsSqlToolBelt/Data/DefinitionExportRepo.cs
+++ b/src/MsSqlToolBelt/Data/DefinitionExportRepo.cs
@@ -223,6 +223,7 @@ internal class DefinitionExportRepo : BaseRepo
             .AppendLine(" NOTE / ATTENTION")
             .AppendLine(" ----------------")
             .AppendLine(" The following script was generated automatically. Please check the content before you execute the script!")
+            .AppendLine(" In addition to the actual create script, all dependencies are generated as well.")
             .AppendLine("*/")
             .AppendLine();
     }

--- a/src/MsSqlToolBelt/DataObjects/Search/SearchResult.cs
+++ b/src/MsSqlToolBelt/DataObjects/Search/SearchResult.cs
@@ -115,7 +115,7 @@ internal class SearchResult
             Name = job.Name,
             Info = $"{enableInfo}, {jobVersion}",
             Type = "Job",
-            EntryType = EntryType.TableType,
+            EntryType = EntryType.Job,
             CreationDateTime = job.CreationDateTime,
             ModifiedDateTime = job.ModifiedDateTime,
             BoundItem = job

--- a/src/MsSqlToolBelt/Ui/View/Controls/SearchControl.xaml
+++ b/src/MsSqlToolBelt/Ui/View/Controls/SearchControl.xaml
@@ -5,6 +5,7 @@
     xmlns:avalonedit="http://icsharpcode.net/sharpdevelop/avalonedit"
     xmlns:controls="clr-namespace:MsSqlToolBelt.Ui.ViewModel.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
     xmlns:local="clr-namespace:MsSqlToolBelt.Ui.View.Controls"
     xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -178,6 +179,31 @@
 
         <GridSplitter Grid.Row="1" Style="{StaticResource HorizontalSplitter}" />
 
+        <!--  Main  -->
+        <Border
+            Grid.Row="2"
+            Style="{StaticResource BorderStyle}"
+            Visibility="{Binding ShowMain}">
+            <Grid>
+
+                <iconPacks:PackIconPixelartIcons
+                    Width="100"
+                    Height="100"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Foreground="#2a2a2a"
+                    Kind="HumanRun" />
+
+                <Label
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Content="Select an entry to view the data here..." />
+
+            </Grid>
+
+
+        </Border>
+
         <!--  SQL Text  -->
         <Border
             Grid.Row="2"
@@ -226,7 +252,7 @@
             Grid.Row="2"
             Style="{StaticResource BorderStyle}"
             Visibility="{Binding ShowTableGrid, Converter={StaticResource BooleanToVisibilityConverter}}">
-            <TabControl>
+            <TabControl SelectedIndex="{Binding TableTabIndex}">
                 <TabItem Header="Columns">
                     <Grid>
                         <Grid.RowDefinitions>
@@ -322,6 +348,14 @@
 
                         <Button
                             Grid.Row="4"
+                            Grid.Column="0"
+                            Width="75"
+                            HorizontalAlignment="Left"
+                            Command="{Binding ReloadDataCommand}"
+                            Content="Reload" />
+
+                        <Button
+                            Grid.Row="4"
                             Width="100"
                             HorizontalAlignment="Right"
                             Command="{Binding CopyExportTableCommand}"
@@ -378,6 +412,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
@@ -406,9 +441,19 @@
                     Grid.Column="0"
                     Grid.ColumnSpan="3" />
 
+                <TextBox
+                    Grid.Row="2"
+                    Grid.Column="0"
+                    mah:TextBoxHelper.Watermark="Filter"
+                    Text="{Binding JobFilter, UpdateSourceTrigger=PropertyChanged}">
+                    <TextBox.InputBindings>
+                        <KeyBinding Key="Enter" Command="{Binding FilterJobCommand}" />
+                    </TextBox.InputBindings>
+                </TextBox>
+
                 <DataGrid
                     Name="DataGridJob"
-                    Grid.Row="2"
+                    Grid.Row="3"
                     Grid.Column="0"
                     IsReadOnly="True"
                     ItemsSource="{Binding JobSteps}"
@@ -440,12 +485,23 @@
                     </DataGrid.Columns>
                 </DataGrid>
 
+                <Button
+                    Grid.Row="4"
+                    Grid.Column="0"
+                    Width="75"
+                    HorizontalAlignment="Left"
+                    Command="{Binding ReloadDataCommand}"
+                    Content="Reload" />
+
                 <GridSplitter
                     Grid.Row="2"
                     Grid.Column="1"
                     Style="{StaticResource VerticalSplitter}" />
 
-                <Grid Grid.Row="2" Grid.Column="2">
+                <Grid
+                    Grid.Row="2"
+                    Grid.RowSpan="2"
+                    Grid.Column="2">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />

--- a/src/MsSqlToolBelt/Ui/View/Controls/SearchControl.xaml
+++ b/src/MsSqlToolBelt/Ui/View/Controls/SearchControl.xaml
@@ -183,7 +183,7 @@
         <Border
             Grid.Row="2"
             Style="{StaticResource BorderStyle}"
-            Visibility="{Binding ShowMain}">
+            Visibility="{Binding ShowMain, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Grid>
 
                 <iconPacks:PackIconPixelartIcons
@@ -445,6 +445,7 @@
                     Grid.Row="2"
                     Grid.Column="0"
                     mah:TextBoxHelper.Watermark="Filter"
+                    Style="{StaticResource TextBoxFilter}"
                     Text="{Binding JobFilter, UpdateSourceTrigger=PropertyChanged}">
                     <TextBox.InputBindings>
                         <KeyBinding Key="Enter" Command="{Binding FilterJobCommand}" />
@@ -484,14 +485,6 @@
                             Header="Last duration" />
                     </DataGrid.Columns>
                 </DataGrid>
-
-                <Button
-                    Grid.Row="4"
-                    Grid.Column="0"
-                    Width="75"
-                    HorizontalAlignment="Left"
-                    Command="{Binding ReloadDataCommand}"
-                    Content="Reload" />
 
                 <GridSplitter
                     Grid.Row="2"
@@ -599,12 +592,20 @@
                 </Grid>
 
                 <Separator
-                    Grid.Row="3"
+                    Grid.Row="4"
                     Grid.Column="0"
                     Grid.ColumnSpan="3" />
 
                 <Button
-                    Grid.Row="4"
+                    Grid.Row="5"
+                    Grid.Column="0"
+                    Width="75"
+                    HorizontalAlignment="Left"
+                    Command="{Binding ReloadDataCommand}"
+                    Content="Reload" />
+
+                <Button
+                    Grid.Row="5"
                     Grid.Column="2"
                     Width="100"
                     HorizontalAlignment="Right"

--- a/src/MsSqlToolBelt/Ui/ViewModel/Controls/SearchControlViewModel.cs
+++ b/src/MsSqlToolBelt/Ui/ViewModel/Controls/SearchControlViewModel.cs
@@ -634,7 +634,7 @@ internal partial class SearchControlViewModel : ViewModelBase, IConnection
     private void SetVisibility(SearchViewType type)
     {
         // Grids
-        ShowMain = true;
+        ShowMain = false;
         ShowJobGrid = false;
         ShowSql = false;
         ShowTableGrid = false;


### PR DESCRIPTION
## Changes

- Moved the function to load the table definition into it's own method to increase the loading time. Definition is now loaded only when it's needed
- Added check to bypass the progress dialog when no data is loaded (added check if the data already loaded)
- Added reload function
- Added job filter (filter for the job steps)