### PR TITLE
Copy name

### DIFF
--- a/src/MsSqlToolBelt/Business/SettingsManager.cs
+++ b/src/MsSqlToolBelt/Business/SettingsManager.cs
@@ -51,6 +51,31 @@ public class SettingsManager
     }
 
     /// <summary>
+    /// Loads the specified settings value
+    /// </summary>
+    /// <typeparam name="T">The type of the value</typeparam>
+    /// <param name="key">The desired key</param>
+    /// <param name="fallback">The desired fallback</param>
+    /// <returns>The value</returns>
+    public static T LoadSettingsValue<T>(SettingsKey key, T? fallback = default)
+    {
+        using var context = new AppDbContext();
+        var value = context.Settings.FirstOrDefault(f => f.KeyId == (int)key);
+        if (value == null)
+            return fallback == null ? Activator.CreateInstance<T>() : fallback;
+
+        try
+        {
+            return (T)Convert.ChangeType(value.Value, typeof(T));
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error while loading settings value. Key {key}", key);
+            return fallback == null ? Activator.CreateInstance<T>() : fallback;
+        }
+    }
+
+    /// <summary>
     /// Saves a settings value
     /// </summary>
     /// <param name="key">The desired key</param>

--- a/src/MsSqlToolBelt/Common/ClipboardPropertyAttribute.cs
+++ b/src/MsSqlToolBelt/Common/ClipboardPropertyAttribute.cs
@@ -1,0 +1,9 @@
+﻿namespace MsSqlToolBelt.Common;
+
+/// <summary>
+/// The attribute which indicates if the property should be used when a single line of a grid is copied with CTRL + C
+/// <para />
+/// <b>NOTE</b>: If the property is linked to more than one property, the first occurrence is used!
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+internal class ClipboardPropertyAttribute : Attribute;

--- a/src/MsSqlToolBelt/Common/Enums/SettingsKey.cs
+++ b/src/MsSqlToolBelt/Common/Enums/SettingsKey.cs
@@ -33,5 +33,10 @@ public enum SettingsKey
     /// <summary>
     /// The search options
     /// </summary>
-    SearchOptions = 5
+    SearchOptions = 5,
+
+    /// <summary>
+    /// Specifies whether only the name should be copied if only one row is selected in the grid.
+    /// </summary>
+    CopyGridSingleLineOnlyValue = 6
 }

--- a/src/MsSqlToolBelt/Common/Helper.cs
+++ b/src/MsSqlToolBelt/Common/Helper.cs
@@ -5,6 +5,8 @@ using Microsoft.WindowsAPICodePack.Taskbar;
 using MsSqlToolBelt.Common.Enums;
 using MsSqlToolBelt.Data.Internal;
 using MsSqlToolBelt.DataObjects.Common;
+using MsSqlToolBelt.DataObjects.Internal;
+using Newtonsoft.Json;
 using Serilog;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -13,8 +15,6 @@ using System.Reflection;
 using System.Text;
 using System.Windows;
 using System.Windows.Media;
-using MsSqlToolBelt.DataObjects.Internal;
-using Newtonsoft.Json;
 using ZimLabs.CoreLib;
 
 namespace MsSqlToolBelt.Common;
@@ -308,6 +308,30 @@ internal static class Helper
         var tmpValue = string.Join("", values);
 
         return tmpValue.GetHashCode();
+    }
+
+    /// <summary>
+    /// Gets the copy value of the item.
+    /// <para />
+    /// The value is determined by the <see cref="ClipboardPropertyAttribute"/>
+    /// <para />
+    /// <b>NOTE</b>: If the property is linked to more than one property, the first occurrence is used!
+    /// </summary>
+    /// <param name="item">The item</param>
+    /// <returns>The value of the specified property</returns>
+    public static string GetCopyValue(this object item)
+    {
+        var properties = item.GetType().GetProperties();
+        foreach (var property in properties)
+        {
+            var attribute = property.GetCustomAttribute<ClipboardPropertyAttribute>();
+            if (attribute == null)
+                continue;
+
+            return property.GetValue(item)?.ToString() ?? string.Empty;
+        }
+
+        return string.Empty;
     }
 
     #region Taskbar

--- a/src/MsSqlToolBelt/DataObjects/ClassGen/ColumnDto.cs
+++ b/src/MsSqlToolBelt/DataObjects/ClassGen/ColumnDto.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using MsSqlToolBelt.Common;
 using MsSqlToolBelt.DataObjects.Common;
 
 namespace MsSqlToolBelt.DataObjects.ClassGen;
@@ -25,6 +26,7 @@ public class ColumnDto : ObservableObject
     /// <summary>
     /// Gets or sets the name of the column
     /// </summary>
+    [ClipboardProperty]
     public string Name { get; set; } = string.Empty;
 
     /// <summary>

--- a/src/MsSqlToolBelt/DataObjects/ClassGen/TableDto.cs
+++ b/src/MsSqlToolBelt/DataObjects/ClassGen/TableDto.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using MsSqlToolBelt.Common;
 using MsSqlToolBelt.Common.Enums;
 using MsSqlToolBelt.DataObjects.Common;
 using MsSqlToolBelt.DataObjects.TableType;
@@ -15,6 +16,7 @@ public class TableDto : ObservableObject
     /// <summary>
     /// Gets or sets the name of the table
     /// </summary>
+    [ClipboardProperty]
     public string Name { get; init; } = string.Empty;
 
     /// <summary>

--- a/src/MsSqlToolBelt/DataObjects/Common/ColumnEntry.cs
+++ b/src/MsSqlToolBelt/DataObjects/Common/ColumnEntry.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using MsSqlToolBelt.Common;
+using Newtonsoft.Json;
 using ZimLabs.TableCreator;
 
 namespace MsSqlToolBelt.DataObjects.Common;
@@ -12,6 +13,7 @@ public class ColumnEntry
     /// <summary>
     /// Gets or sets the name of the column
     /// </summary>
+    [ClipboardProperty]
     public string Name { get; set; } = string.Empty;
 
     /// <summary>

--- a/src/MsSqlToolBelt/DataObjects/Common/IdNameBase.cs
+++ b/src/MsSqlToolBelt/DataObjects/Common/IdNameBase.cs
@@ -1,4 +1,6 @@
-﻿namespace MsSqlToolBelt.DataObjects.Common;
+﻿using MsSqlToolBelt.Common;
+
+namespace MsSqlToolBelt.DataObjects.Common;
 
 /// <summary>
 /// Represents a simple id / name entry
@@ -13,5 +15,6 @@ public class IdNameBase
     /// <summary>
     /// Gets or sets the name of the table
     /// </summary>
+    [ClipboardProperty]
     public string Name { get; set; } = string.Empty;
 }

--- a/src/MsSqlToolBelt/DataObjects/Common/PackageInfo.cs
+++ b/src/MsSqlToolBelt/DataObjects/Common/PackageInfo.cs
@@ -1,4 +1,6 @@
-﻿namespace MsSqlToolBelt.DataObjects.Common;
+﻿using MsSqlToolBelt.Common;
+
+namespace MsSqlToolBelt.DataObjects.Common;
 
 /// <summary>
 /// Represents a package entry
@@ -8,6 +10,7 @@ internal class PackageInfo
     /// <summary>
     /// Gets or sets the name of the package
     /// </summary>
+    [ClipboardProperty]
     public string Name { get; set; } = string.Empty;
 
     /// <summary>

--- a/src/MsSqlToolBelt/DataObjects/DefinitionExport/DefinitionExportObject.cs
+++ b/src/MsSqlToolBelt/DataObjects/DefinitionExport/DefinitionExportObject.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using MsSqlToolBelt.Common;
 using MsSqlToolBelt.Common.Enums;
 using MsSqlToolBelt.DataObjects.Common;
 using MsSqlToolBelt.DataObjects.TableType;
@@ -31,6 +32,7 @@ internal class DefinitionExportObject : ObservableObject
     /// <summary>
     /// Gets the name of the object
     /// </summary>
+    [ClipboardProperty]
     public string Name { get; init; } = string.Empty;
 
     /// <summary>

--- a/src/MsSqlToolBelt/DataObjects/Internal/ServerEntry.cs
+++ b/src/MsSqlToolBelt/DataObjects/Internal/ServerEntry.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using MsSqlToolBelt.Common;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace MsSqlToolBelt.DataObjects.Internal;
@@ -20,6 +21,7 @@ public class ServerEntry
     /// Gets or sets the name / path of the sever
     /// </summary>
     [Required]
+    [ClipboardProperty]
     public string Name { get; set; } = string.Empty;
 
     /// <summary>

--- a/src/MsSqlToolBelt/DataObjects/Search/IndexEntry.cs
+++ b/src/MsSqlToolBelt/DataObjects/Search/IndexEntry.cs
@@ -1,4 +1,6 @@
-﻿namespace MsSqlToolBelt.DataObjects.Search;
+﻿using MsSqlToolBelt.Common;
+
+namespace MsSqlToolBelt.DataObjects.Search;
 
 /// <summary>
 /// Represents an table index
@@ -8,6 +10,7 @@ public class IndexEntry
     /// <summary>
     /// Gets or sets the name of the index
     /// </summary>
+    [ClipboardProperty]
     public string Name { get; set; } = string.Empty;
 
     /// <summary>

--- a/src/MsSqlToolBelt/DataObjects/Search/SearchResult.cs
+++ b/src/MsSqlToolBelt/DataObjects/Search/SearchResult.cs
@@ -1,4 +1,5 @@
-﻿using MsSqlToolBelt.Common.Enums;
+﻿using MsSqlToolBelt.Common;
+using MsSqlToolBelt.Common.Enums;
 using MsSqlToolBelt.DataObjects.Common;
 using MsSqlToolBelt.DataObjects.TableType;
 using Newtonsoft.Json;
@@ -14,6 +15,7 @@ internal class SearchResult
     /// <summary>
     /// Gets or sets the name
     /// </summary>
+    [ClipboardProperty]
     public string Name { get; init; } = string.Empty;
 
     /// <summary>

--- a/src/MsSqlToolBelt/DataObjects/TableType/TableTypeEntry.cs
+++ b/src/MsSqlToolBelt/DataObjects/TableType/TableTypeEntry.cs
@@ -1,4 +1,5 @@
-﻿using MsSqlToolBelt.DataObjects.Common;
+﻿using MsSqlToolBelt.Common;
+using MsSqlToolBelt.DataObjects.Common;
 using Newtonsoft.Json;
 using ZimLabs.TableCreator;
 
@@ -17,6 +18,7 @@ public class TableTypeEntry
     /// <summary>
     /// Gets or sets the name of the table type
     /// </summary>
+    [ClipboardProperty]
     public string Name { get; set; } = string.Empty;
 
     /// <summary>

--- a/src/MsSqlToolBelt/Ui/View/Controls/ClassGenControl.xaml.cs
+++ b/src/MsSqlToolBelt/Ui/View/Controls/ClassGenControl.xaml.cs
@@ -1,14 +1,14 @@
-﻿using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
-using System.Windows.Navigation;
-using ICSharpCode.AvalonEdit.Search;
+﻿using ICSharpCode.AvalonEdit.Search;
 using MsSqlToolBelt.Business;
 using MsSqlToolBelt.Common;
 using MsSqlToolBelt.Common.Enums;
 using MsSqlToolBelt.DataObjects.ClassGen;
 using MsSqlToolBelt.Ui.Common;
 using MsSqlToolBelt.Ui.ViewModel.Controls;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Navigation;
 
 namespace MsSqlToolBelt.Ui.View.Controls;
 
@@ -88,7 +88,7 @@ public partial class ClassGenControl : UserControl, IUserControl
     /// <summary>
     /// Occurs when the user hits the link
     /// </summary>
-    /// <param name="sender">The hyper link</param>
+    /// <param name="sender">The hyperlink</param>
     /// <param name="e">The event arguments</param>
     private void Hyperlink_OnRequestNavigate(object sender, RequestNavigateEventArgs e)
     {

--- a/src/MsSqlToolBelt/Ui/View/Controls/InfoControl.xaml.cs
+++ b/src/MsSqlToolBelt/Ui/View/Controls/InfoControl.xaml.cs
@@ -1,15 +1,14 @@
-﻿using System;
-using System.Windows.Controls;
-using System.Windows.Input;
-using System.Windows.Navigation;
-using System.Windows.Threading;
-using MsSqlToolBelt.Business;
+﻿using MsSqlToolBelt.Business;
 using MsSqlToolBelt.Common;
 using MsSqlToolBelt.Common.Enums;
 using MsSqlToolBelt.DataObjects.Common;
 using MsSqlToolBelt.Ui.Common;
 using MsSqlToolBelt.Ui.ViewModel.Controls;
 using Serilog;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Navigation;
+using System.Windows.Threading;
 
 namespace MsSqlToolBelt.Ui.View.Controls;
 

--- a/src/MsSqlToolBelt/Ui/View/Controls/SearchControl.xaml.cs
+++ b/src/MsSqlToolBelt/Ui/View/Controls/SearchControl.xaml.cs
@@ -1,12 +1,12 @@
-﻿using System.Windows.Controls;
-using System.Windows.Input;
-using ICSharpCode.AvalonEdit.Search;
+﻿using ICSharpCode.AvalonEdit.Search;
 using MsSqlToolBelt.Business;
 using MsSqlToolBelt.Common.Enums;
 using MsSqlToolBelt.DataObjects.Common;
 using MsSqlToolBelt.DataObjects.Search;
 using MsSqlToolBelt.Ui.Common;
 using MsSqlToolBelt.Ui.ViewModel.Controls;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace MsSqlToolBelt.Ui.View.Controls;
 

--- a/src/MsSqlToolBelt/Ui/View/Controls/SettingsControl.xaml
+++ b/src/MsSqlToolBelt/Ui/View/Controls/SettingsControl.xaml
@@ -264,6 +264,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="32" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
@@ -304,22 +305,48 @@
                 <Label
                     Grid.Row="3"
                     Grid.Column="0"
+                    Content="Copy only 'name':">
+                    <Label.ToolTip>
+                        Note: If the grid does not have a 'Name' column, the entire content of the column is copied in the specified format (see Copy format)
+                    </Label.ToolTip>
+                </Label>
+                <CheckBox
+                    Grid.Row="3"
+                    Grid.Column="1"
+                    IsChecked="{Binding CopyGridSingleLineOnlyValue}">
+                    <CheckBox.ToolTip>
+                        Note: If the grid does not have a 'Name' column, the entire content of the column is copied in the specified format (see Copy format)
+                    </CheckBox.ToolTip>
+                </CheckBox>
+                <Label
+                    Grid.Row="3"
+                    Grid.Column="2"
+                    Content="If selected, only the 'name' of a column is copied if only one row is selected."
+                    Style="{StaticResource ItemHint}">
+                    <Label.ToolTip>
+                        Note: If the grid does not have a 'Name' column, the entire content of the column is copied in the specified format (see Copy format)
+                    </Label.ToolTip>
+                </Label>
+
+                <Label
+                    Grid.Row="4"
+                    Grid.Column="0"
                     Content="Search history count:" />
                 <mah:NumericUpDown
-                    Grid.Row="3"
+                    Grid.Row="4"
                     Grid.Column="1"
                     Margin="3"
                     Minimum="0"
                     NumericInputMode="Numbers"
                     Value="{Binding SearchHistoryCount}" />
                 <Label
-                    Grid.Row="3"
+                    Grid.Row="4"
                     Grid.Column="2"
-                    Content="The number of search history entries (0 = infitiniy)"
+                    Content="The number of search history entries (0 = infinity)"
                     Style="{StaticResource ItemHint}" />
 
                 <Button
-                    Grid.Row="4"
+                    Grid.Row="5"
                     Grid.Column="0"
                     Grid.ColumnSpan="3"
                     Width="60"

--- a/src/MsSqlToolBelt/Ui/View/Controls/SettingsControl.xaml.cs
+++ b/src/MsSqlToolBelt/Ui/View/Controls/SettingsControl.xaml.cs
@@ -1,9 +1,9 @@
-﻿using System.Windows.Controls;
-using System.Windows.Input;
-using MsSqlToolBelt.Business;
+﻿using MsSqlToolBelt.Business;
 using MsSqlToolBelt.DataObjects.Internal;
 using MsSqlToolBelt.Ui.Common;
 using MsSqlToolBelt.Ui.ViewModel.Controls;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace MsSqlToolBelt.Ui.View.Controls;
 

--- a/src/MsSqlToolBelt/Ui/View/Controls/TableTypesControl.xaml.cs
+++ b/src/MsSqlToolBelt/Ui/View/Controls/TableTypesControl.xaml.cs
@@ -1,10 +1,10 @@
-﻿using System.Windows.Controls;
-using System.Windows.Input;
-using MsSqlToolBelt.DataObjects.Common;
+﻿using MsSqlToolBelt.DataObjects.Common;
 using MsSqlToolBelt.DataObjects.TableType;
 using MsSqlToolBelt.Ui.Common;
 using MsSqlToolBelt.Ui.View.Common;
 using MsSqlToolBelt.Ui.ViewModel.Controls;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace MsSqlToolBelt.Ui.View.Controls;
 

--- a/src/MsSqlToolBelt/Ui/View/Windows/ClassGenWindow.xaml.cs
+++ b/src/MsSqlToolBelt/Ui/View/Windows/ClassGenWindow.xaml.cs
@@ -1,14 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
-using System.Windows.Navigation;
-using MahApps.Metro.Controls;
+﻿using MahApps.Metro.Controls;
 using MsSqlToolBelt.Business;
 using MsSqlToolBelt.Common;
 using MsSqlToolBelt.DataObjects.ClassGen;
 using MsSqlToolBelt.Ui.Common;
 using MsSqlToolBelt.Ui.ViewModel.Windows;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Navigation;
 
 namespace MsSqlToolBelt.Ui.View.Windows;
 

--- a/src/MsSqlToolBelt/Ui/View/Windows/DataTypeWindow.xaml.cs
+++ b/src/MsSqlToolBelt/Ui/View/Windows/DataTypeWindow.xaml.cs
@@ -1,9 +1,9 @@
-﻿using System.Windows;
-using System.Windows.Input;
-using MahApps.Metro.Controls;
+﻿using MahApps.Metro.Controls;
 using MsSqlToolBelt.DataObjects.ClassGen;
 using MsSqlToolBelt.Ui.Common;
 using MsSqlToolBelt.Ui.ViewModel.Windows;
+using System.Windows;
+using System.Windows.Input;
 
 namespace MsSqlToolBelt.Ui.View.Windows;
 

--- a/src/MsSqlToolBelt/Ui/View/Windows/MainWindow.xaml
+++ b/src/MsSqlToolBelt/Ui/View/Windows/MainWindow.xaml
@@ -60,7 +60,7 @@
     <mah:MetroWindow.Flyouts>
         <mah:FlyoutsControl>
             <mah:Flyout
-                Width="600"
+                Width="725"
                 ClosingFinished="Flyout_OnClosingFinished"
                 Header="Settings"
                 IsOpen="{Binding SettingsOpen}"

--- a/src/MsSqlToolBelt/Ui/ViewModel/Controls/SettingsControlViewModel.cs
+++ b/src/MsSqlToolBelt/Ui/ViewModel/Controls/SettingsControlViewModel.cs
@@ -154,10 +154,16 @@ internal partial class SettingsControlViewModel : ViewModelBase
     /// </summary>
     [ObservableProperty]
     private int _searchHistoryCount = 50;
+
+    /// <summary>
+    /// Gets or sets the value which specifies whether only the name should be copied if only one row is selected in the grid.
+    /// </summary>
+    [ObservableProperty]
+    private bool _copyGridSingleLineOnlyValue;
     #endregion
 
     #endregion
-    
+
     /// <summary>
     /// Init the view model
     /// </summary>
@@ -195,10 +201,15 @@ internal partial class SettingsControlViewModel : ViewModelBase
             // Set the various data
             var exportList = Helper.CreateExportTypeList(ExportDataType.List);
             ExportTypes = new ObservableCollection<IdTextEntry>(exportList);
-            var exportType = await SettingsManager.LoadSettingsValueAsync(SettingsKey.CopyToClipboardFormat, DefaultEntries.CopyToClipboardFormat); // 1 = CSV
+            var exportType = await SettingsManager.LoadSettingsValueAsync(SettingsKey.CopyToClipboardFormat,
+                DefaultEntries.CopyToClipboardFormat); // 1 = CSV
             SelectedExportType = exportList.FirstOrDefault(f => f.Id == exportType);
 
-            SearchHistoryCount = await SettingsManager.LoadSettingsValueAsync(SettingsKey.SearchHistoryEntryCount, DefaultEntries.SearchHistoryCount);
+            SearchHistoryCount = await SettingsManager.LoadSettingsValueAsync(SettingsKey.SearchHistoryEntryCount,
+                DefaultEntries.SearchHistoryCount);
+
+            CopyGridSingleLineOnlyValue =
+                await SettingsManager.LoadSettingsValueAsync(SettingsKey.CopyGridSingleLineOnlyValue, false);
         }
         catch (Exception ex)
         {
@@ -555,8 +566,9 @@ internal partial class SettingsControlViewModel : ViewModelBase
         {
             var saveList = new SortedList<SettingsKey, object>
             {
-                {SettingsKey.CopyToClipboardFormat, SelectedExportType.Id},
-                {SettingsKey.SearchHistoryEntryCount, SearchHistoryCount}
+                { SettingsKey.CopyToClipboardFormat, SelectedExportType.Id },
+                { SettingsKey.SearchHistoryEntryCount, SearchHistoryCount },
+                { SettingsKey.CopyGridSingleLineOnlyValue, CopyGridSingleLineOnlyValue }
             };
 
             await SettingsManager.SaveSettingsValuesAsync(saveList);

--- a/src/MsSqlToolBelt/Ui/ViewModel/Controls/TableTypesControlViewModel.cs
+++ b/src/MsSqlToolBelt/Ui/ViewModel/Controls/TableTypesControlViewModel.cs
@@ -178,7 +178,12 @@ internal partial class TableTypesControlViewModel : ViewModelBase, IConnection
             : _manager.TableTypes.Where(w => w.Name.ContainsIgnoreCase(Filter)).ToList();
 
         TableTypes = result.ToObservableCollection();
-        HeaderList = TableTypes.Count > 1 ? $"{TableTypes.Count} table types" : "1 table type";
+        HeaderList = TableTypes.Count switch
+        {
+            0 => "No table types available",
+            1 => "1 table type",
+            _ => $"{TableTypes.Count} table types"
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
## Whats changed?

If only one row of a grid is selected, only the content of the *Name* column is copied. If there is no column with the name *Name*, the *old* behavior is applied.

The settings can also be used to specify whether the function described above is desired or not. If the function is not activated, the *old* behavior is applied.